### PR TITLE
feat:  docker multiarch arm64

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,6 +3,8 @@ name: Build and Push Docker Image
 on:
   push:
     tags: ["v*"]
+  pull_request:
+    branches: ["main"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -41,6 +43,9 @@ jobs:
             type=sha
             type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -48,7 +53,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: true
+          push: ${{ github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -57,7 +63,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Fly.io
+        if: ${{ github.event_name == 'push' }}
         uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --image ${{ env.REGISTRY }}/${IMAGE_NAME,,}:${{ steps.meta.outputs.version }}
+        if: ${{ github.event_name == 'push' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,13 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: "Push image to GHCR"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -39,9 +46,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=sha
-            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -53,7 +60,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -63,9 +70,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Fly.io
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && secrets.FLY_API_TOKEN != '' }}
         uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --image ${{ env.REGISTRY }}/${IMAGE_NAME,,}:${{ steps.meta.outputs.version }}
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && secrets.FLY_API_TOKEN != '' }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
 jobs:
   build-and-push:
@@ -70,9 +71,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Fly.io
-        if: ${{ github.event_name == 'push' && secrets.FLY_API_TOKEN != '' }}
+        if: ${{ github.event_name == 'push' && env.FLY_API_TOKEN != '' }}
         uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --image ${{ env.REGISTRY }}/${IMAGE_NAME,,}:${{ steps.meta.outputs.version }}
-        if: ${{ github.event_name == 'push' && secrets.FLY_API_TOKEN != '' }}
+        if: ${{ github.event_name == 'push' && env.FLY_API_TOKEN != '' }}
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,13 @@ on:
     tags: ["v*"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
+    inputs:
+      push_image:
+        description: "Push image to GHCR"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,6 +20,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
 jobs:
   build-and-push:
@@ -39,9 +47,9 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=sha
-            type=raw,value=latest,enable=${{ !contains(github.ref, '-') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -53,7 +61,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          push: ${{ github.event_name == 'push' }}
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -63,9 +71,9 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Deploy to Fly.io
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.FLY_API_TOKEN != '' }}
         uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --image ${{ env.REGISTRY }}/${IMAGE_NAME,,}:${{ steps.meta.outputs.version }}
-        if: ${{ github.event_name == 'push' }}
+        if: ${{ github.event_name == 'push' && env.FLY_API_TOKEN != '' }}
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          FLY_API_TOKEN: ${{ env.FLY_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ volumes:
 docker compose up -d
 ```
 
+Published images on GHCR are multi-arch and include `linux/amd64` and `linux/arm64`.
+
 ### 5. Open your browser
 
 Navigate to [http://localhost:3000](http://localhost:3000), log in with your credentials, and hit the **scan** button to index your library.


### PR DESCRIPTION
This pull request updates the Docker build and deployment workflow to add support for multi-architecture images, improve deployment flexibility, and enhance workflow triggers. The changes also update the documentation to reflect these improvements.

**Workflow improvements:**

* The workflow now builds and pushes multi-architecture Docker images for both `linux/amd64` and `linux/arm64` platforms. (`.github/workflows/docker-publish.yml`) [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98L51-R65) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R181-R182)
* Added support for running the workflow on pull requests to the `main` branch and via manual dispatch, with an option to control image pushing. (`.github/workflows/docker-publish.yml`)
* Improved Docker image tagging logic to only apply `latest` and major/minor tags for versioned tags, preventing accidental tagging on non-release builds. (`.github/workflows/docker-publish.yml`)

**Deployment enhancements:**

* Deployment to Fly.io now only occurs on `push` events when the `FLY_API_TOKEN` is set, preventing unintended deployments. (`.github/workflows/docker-publish.yml`) [[1]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R74-R79) [[2]](diffhunk://#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98R23)

**Documentation update:**

* Updated the `README.md` to mention that published images are multi-arch, supporting both `linux/amd64` and `linux/arm64`. (`README.md`)